### PR TITLE
Introduce protos required for kafka cache

### DIFF
--- a/src/com/coralogixapis/alerts/v5/event/key/alert_def_cache/alert_def_cache_key.proto
+++ b/src/com/coralogixapis/alerts/v5/event/key/alert_def_cache/alert_def_cache_key.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package com.coralogixapis.alerts.v5;
+
+message AlertDefCacheKey {
+  string company_id = 1;
+  string alert_def_id = 2;
+}

--- a/src/com/coralogixapis/alerts/v5/event/payload/alert_def_cache/alert_def_cache_value.proto
+++ b/src/com/coralogixapis/alerts/v5/event/payload/alert_def_cache/alert_def_cache_value.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package com.coralogixapis.alerts.v5;
+
+import "com/coralogixapis/alerts/v3/alert_def.proto";
+
+message AlertDefCacheValue {
+  optional AlertDef alert_def = 1;
+}


### PR DESCRIPTION
Introduce 2 protos for key values in kafka. Kafka will function as a cache of alert definitions.

The key is composed of company_id and user_alert_defintion_id - we could use just one, but it is useful to have both and will remain appropriately unique.

The value is declared so we have access to an optional alert definition, however using no value is preferable.